### PR TITLE
fix: install mediapipe-silicon when arm64 macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     install_requires=[
         "numpy~=1.20",
         "opencv-contrib-python~=4.5.4",  # pylint goes bananas with 4.6.xxx
-        "mediapipe~=0.8",
+        'mediapipe-silicon~=0.8; platform_system=="Darwin" and platform.machine=="arm64"',
+        'mediapipe~=0.8',
         'windows-curses~=2.3; platform_system=="Windows"',
     ],
     extras_require={


### PR DESCRIPTION
Encountered the following error:

<img width="1216" alt="Screenshot 2022-10-02 at 18 45 51" src="https://user-images.githubusercontent.com/10052309/193481677-354d15ef-dded-4126-b34c-e80333c7eefb.png">

Relevant discussion: https://github.com/google/mediapipe/issues/3656#issuecomment-1235200591

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>